### PR TITLE
Fix GitHub link rendering

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { from, concat, of } from 'rxjs'
+import { concat, from, of } from 'rxjs'
 import { filter, switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { from } from 'rxjs'
+import { from, concat, of } from 'rxjs'
 import { filter, switchMap } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 import {
@@ -34,7 +34,10 @@ const COMMON_ERRORLOG_PATTERNS = [
 
 // TODO: Refactor to use activeEditor
 export function activate(context: sourcegraph.ExtensionContext): void {
-    sourcegraph.workspace.openedTextDocuments.subscribe(textDocument => {
+    concat(
+        ...sourcegraph.workspace.textDocuments.map(doc => of(doc)),
+        from(sourcegraph.workspace.onDidOpenTextDocument)
+    ).subscribe(textDocument => {
         const params: Params = getParamsFromUriPath(textDocument.uri)
         const sentryProjects = SETTINGSCONFIG['sentry.projects']
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
 }
 
 /**
- * Get and varify the necessary uri and config data and build the decorations
+ * Get and varify the necessary uri and config data and build the decorations.
  * @param editor
  * @param sentryProjects
  */
@@ -85,7 +85,7 @@ export function getDecorations(
 }
 
 /**
- * Build decorations by matching error handling code with either user config or common error patterns
+ * Build decorations by matching error handling code with either user config or common error patterns.
  * @param editor
  * @param missingConfigData
  * @param sentryProjectId

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -15,16 +15,17 @@ interface LineDecorationText {
  * Extract Sentry params from document URI necessary to
  * check if the current document sends log events to Sentry and
  * use these params build URL to the Sentry issues stream page.
- * @param textDocument A document URI.
+ * @param textDocumentURI A document URI.
  * @returns repo and file part of URI.
  */
-export function getParamsFromUriPath(textDocument: string): Params {
+export function getParamsFromUriPath(textDocumentURI: string): Params {
     // TODO: Support more than just GitHub.
     // TODO: Safeguard for cases where repo/fileMatch are null.
     const repoPattern = /github\.com\/([^\?\#\/]+\/[^\?\#\/]*)/gi
-    const filePattern = /#([^\?\#\/]+)\/.*\.?$/gi
-    const repoMatch = repoPattern.exec(textDocument)
-    const fileMatch = filePattern.exec(textDocument)
+    const filePattern = /#.*\.(.*)$/gi
+
+    const repoMatch = repoPattern.exec(textDocumentURI)
+    const fileMatch = filePattern.exec(textDocumentURI)
     return {
         repo: repoMatch && repoMatch[1],
         file: fileMatch && fileMatch[0],

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -10,7 +10,13 @@ mock('sourcegraph', sourcegraph)
 import { getParamsFromUriPath, matchSentryProject } from '../handler'
 
 describe('getParamsFromUriPath', () => {
-    it('extracts repo and file params', () =>
+    it('extracts repo and file params from root folder', () =>
+        expect(getParamsFromUriPath('git://github.com/sourcegraph/sourcegraph?264...#index.tsx')).toEqual({
+            repo: 'sourcegraph/sourcegraph',
+            file: '#index.tsx',
+        }))
+
+    it('extracts repo and file params from subfolder', () =>
         expect(
             getParamsFromUriPath('git://github.com/sourcegraph/sourcegraph?264...#web/src/e2e/index.e2e.test.tsx')
         ).toEqual({ repo: 'sourcegraph/sourcegraph', file: '#web/src/e2e/index.e2e.test.tsx' }))


### PR DESCRIPTION
Use `concat` to aggregate and subscribe to the current text document and its changes.