### PR TITLE
add command line and sentry button to show links, enable GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![codecov](https://codecov.io/gh/sourcegraph/sentry/branch/master/graph/badge.svg)](https://codecov.io/gh/sourcegraph/sourcegraph-sentry)
 
-# WIP: Sentry extension
+# Sentry extension
 
 Sentry helps devs track, organize and break down errors more efficiently, facilitating their debug process. We want to make it more convenient for developers to access Sentry's error tracking tools directly from the code that is doing the error handling, code such as `throw new Error(QUERY)`, `console.log(QUERY)`, `console.error(QUERY)` etc..
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Sentry helps devs track, organize and break down errors more efficiently, facilitating their debug process. We want to make it more convenient for developers to access Sentry's error tracking tools directly from the code that is doing the error handling, code such as `throw new Error(QUERY)`, `console.log(QUERY)`, `console.error(QUERY)` etc..
 
-In this first version, the Sentry extension will render a `View logs in Sentry` link on each line it detects such error handling code, leading the devs directly to the corresponding Sentry issues stream page. Links will be rendereed when viewing files on [Sourcegraph](https://sourcegraph.com), GitHub and GitLab. 
+In this first version, the Sentry extension will render a `View logs in Sentry` link on each line it detects such error handling code, leading the devs directly to the corresponding Sentry issues stream page. Links will be rendereed when viewing files on [Sourcegraph](https://sourcegraph.com), GitHub and GitLab.
+
 - **Sentry: Show/hide Sentry**: toggles Sentry links decorations with each matching error handling code.
 
 [**🗃️ Source code**](https://github.com/sourcegraph/sentry)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 [![codecov](https://codecov.io/gh/sourcegraph/sentry/branch/master/graph/badge.svg)](https://codecov.io/gh/sourcegraph/sourcegraph-sentry)
 
-# WIP: Sentry Sourcegraph extension
+# WIP: Sentry extension
 
 Sentry helps devs track, organize and break down errors more efficiently, facilitating their debug process. We want to make it more convenient for developers to access Sentry's error tracking tools directly from the code that is doing the error handling, code such as `throw new Error(QUERY)`, `console.log(QUERY)`, `console.error(QUERY)` etc..
 
-In this first version, the Sentry extension will render a `View logs in Sentry` link on each line it detects such error handling code, leading the devs directly to the corresponding Sentry issues stream page.
+In this first version, the Sentry extension will render a `View logs in Sentry` link on each line it detects such error handling code, leading the devs directly to the corresponding Sentry issues stream page. Links will be rendereed when viewing files on [Sourcegraph](https://sourcegraph.com), GitHub and GitLab. 
+- **Sentry: Show/hide Sentry**: toggles Sentry links decorations with each matching error handling code.
+
+[**🗃️ Source code**](https://github.com/sourcegraph/sentry)
+
+[**➕ Add to Sourcegraph**](https://sourcegraph.com/extensions/sourcegraph/sentry)
 
 ![image](https://user-images.githubusercontent.com/9110008/54014672-d7b4fe00-41c0-11e9-9b92-66d851401fa0.png)
 
@@ -29,7 +34,7 @@ Set the following configurations in your settings:
     "name": "[Project name for the config overview, e.g. Webapp errors]",
     "projectId": "[Sentry project ID, e.g. "1334031"]",
     "patternProperties": {
-      "repoMatch": "[RegExp[] repo names asociated with this Sentry project]",
+      "repoMatches": "[RegExp[] repo names asociated with this Sentry project]",
       "fileMatches": [
           [RegExp[] that matches file format, e.g. "\\.tsx?"]
         ],
@@ -58,7 +63,7 @@ File matches can also be narrowed down to certain folders by specifying this in 
   ```
   ...
   "patternProperties": {
-      "repoMatch": "sourcegraph",
+      "repoMatches": "sourcegraph",
       "fileMatches": ["([^'\"]+)\/.*\\.ts?"],
       "lineMatches": [
           "throw new Error+\\(['\"]([^'\"]+)['\"]\\)",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Sentry helps devs track, organize and break down errors more efficiently, facilitating their debug process. We want to make it more convenient for developers to access Sentry's error tracking tools directly from the code that is doing the error handling, code such as `throw new Error(QUERY)`, `console.log(QUERY)`, `console.error(QUERY)` etc..
 
-In this first version, the Sentry extension will render a `View logs in Sentry` link on each line it detects such error handling code, leading the devs directly to the corresponding Sentry issues stream page. Links will be rendereed when viewing files on [Sourcegraph](https://sourcegraph.com), GitHub and GitLab.
+The Sentry extension renders a `View logs in Sentry` next to error throwing statements, linking directly to the corresponding Sentry issues stream page. Links are rendered when viewing files on [Sourcegraph](https://sourcegraph.com), GitHub and GitLab.
 
 - **Sentry: Show/hide Sentry**: toggles Sentry links decorations with each matching error handling code.
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,53 @@
     "logs"
   ],
   "contributes": {
-    "actions": [],
+    "actions": [
+      {
+        "id": "sentry.decorations.toggle",
+        "command": "updateConfiguration",
+        "commandArguments": [
+          [
+            "sentry.decorations.inline"
+          ],
+          "${!config.sentry.decorations.inline}",
+          null,
+          "json"
+        ],
+        "title": "${config.sentry.decorations.inline && \"Hide\" || \"Show\"} inline Sentry links on file",
+        "category": "Sentry",
+        "actionItem": {
+          "label": "Sentry",
+          "description": "${config.sentry.decorations.inline && \"Hide\" || \"Show\"} inline Sentry links"
+        }
+      }
+    ],
     "menus": {
-      "editor/title": [],
-      "commandPalette": []
+      "editor/title": [
+        {
+          "action": "sentry.decorations.toggle",
+          "alt": "sentry.link.fileList",
+          "when": "resource && !config.sentry.hideSentryButton"
+        }
+
+      ],
+      "commandPalette": [
+        {
+          "action": "sentry.decorations.toggle",
+          "when": "resource"
+        },
+        {
+          "action": "sentry.link.fileList",
+          "when": "resource && get(context, `sentry.fileURL.${resource.uri}`)"
+        },
+        {
+          "action": "sentry.help"
+        }
+      ],
+      "help": [
+        {
+          "action": "sentry.help"
+        }
+      ]
     },
     "configuration": {
       "title": "Sentry extension settings",
@@ -43,16 +86,25 @@
               "type": "string"
             },
             "patternProperties": {
-              "repoMatch": {
-                "type": "string",
+              "repoMatches": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                  },
                 "description": "Regex to match repos associated to this Sentry project, e.g. github\\.com/sourcegraph/sourcegraph"
               },
-              "fileMatch": {
-                "type": "string",
+              "fileMatches": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                  },
                 "description": "Regex to match files associated with this project, e.g. (web|shared)/.*\\.tsx?$"
               },
-              "lineMatch": {
-                "type": "string",
+              "lineMatches": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                  },
                 "description": "Regex to match lines associated with this project, e.g. throw new Error\\([\"']([^'\"]+)[\"']\\)"
               }
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,8 +42,7 @@ const COMMON_ERRORLOG_PATTERNS = [
 const DECORATION_TYPE = sourcegraph.app.createDecorationType()
 
 export function activate(context: sourcegraph.ExtensionContext): void {
-    // TODO(lguychard) sourcegraph.configuration is currently not rxjs-compatible.
-    // Fix this once it has been made compatible.
+    // TODO: Change this when https://github.com/sourcegraph/sourcegraph/issues/3557 is resolved
     const configurationChanges = new BehaviorSubject<void>(undefined)
     context.subscriptions.add(sourcegraph.configuration.subscribe(() => configurationChanges.next(undefined)))
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -21,13 +21,13 @@ interface LineDecorationText {
 export function getParamsFromUriPath(textDocumentURI: string): Params {
     // TODO: Support more than just GitHub.
     // TODO: Safeguard for cases where repo/fileMatch are null.
-    const repoPattern = /github\.com\/([^\?\#\/]+\/[^\?\#\/]*)/gi
+    const repoPattern = /(github\.com|gitlab\.com)\/([^\?\#\/]+\/[^\?\#\/]*)/gi
     const filePattern = /#.*\.(.*)$/gi
 
     const repoMatch = repoPattern.exec(textDocumentURI)
     const fileMatch = filePattern.exec(textDocumentURI)
     return {
-        repo: repoMatch && repoMatch[1],
+        repo: repoMatch && repoMatch[2],
         file: fileMatch && fileMatch[0],
     }
 }
@@ -55,7 +55,6 @@ export function matchSentryProject(params: Params, projects: SentryProject[]): S
             ? !!p.patternProperties.repoMatches.find(repo => !!new RegExp(repo).exec(params.repo!))
             : false
     )
-
     if (!project) {
         return undefined
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -51,8 +51,8 @@ export function matchSentryProject(params: Params, projects: SentryProject[]): S
     // e.g. `sourcegraph-jetbrains` repo will match the `sourcegraph` project
 
     const project = projects.find(p =>
-        p.patternProperties.repoMatch
-            ? !!p.patternProperties.repoMatch.find(repo => !!new RegExp(repo).exec(params.repo!))
+        p.patternProperties.repoMatches
+            ? !!p.patternProperties.repoMatches.find(repo => !!new RegExp(repo).exec(params.repo!))
             : false
     )
 
@@ -115,6 +115,7 @@ export function createDecoration(
             ' Please fill out the following configurations in your Sentry extension settings: ' +
             missingConfigData.join(', ')
     }
+
     return {
         content: contentText,
         hover: hoverText,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@
  * See the "contributes.configuration" field in package.json for the canonical documentation on these properties.
  */
 export interface Settings {
+    ['sentry.decorations.inline']: boolean
     ['sentry.organization']?: string
     ['sentry.projects']?: [SentryProject]
 }
@@ -13,7 +14,7 @@ export interface SentryProject {
     name: string
     projectId: string
     patternProperties: {
-        repoMatch?: RegExp[]
+        repoMatches?: RegExp[]
         fileMatches: RegExp[]
         // RexExp patterns to match log handeling code, e.g. /log\.(Printf|Print)\(['"]([^'"]+)['"]\)/
         lineMatches: RegExp[]
@@ -29,6 +30,7 @@ export interface SentryProject {
 /** Returns a copy of the extension settings with values normalized and defaults applied. */
 export function resolveSettings(raw: Partial<Settings>): Settings {
     return {
+        ['sentry.decorations.inline']: !!raw['sentry.decorations.inline'],
         ['sentry.organization']: raw['sentry.organization'],
         ['sentry.projects']: raw['sentry.projects'],
     }

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -64,12 +64,12 @@ const incompleteConfigs: SentryProject = {
     name: 'sourcegraph',
     projectId: '1334031',
     patternProperties: {
-        repoMatch: undefined,
+        repoMatches: undefined,
         fileMatches: [/(web|shared|src).*\.java?/, /(dev|src).*\.java?/, /.java?/],
         lineMatches: [/logger\.debug\(['"`]([^'"`]+)['"`]\);/],
     },
 }
 
 describe('missingConfig', () => {
-    it('check missing configs', () => expect(checkMissingConfig(incompleteConfigs)).toEqual(['repoMatch']))
+    it('check missing configs', () => expect(checkMissingConfig(incompleteConfigs)).toEqual(['repoMatches']))
 })

--- a/src/test/stubs.ts
+++ b/src/test/stubs.ts
@@ -50,7 +50,7 @@ export let projects: SentryProject[] = [
         name: 'Webapp typescript errors',
         projectId: '1334031',
         patternProperties: {
-            repoMatch: [/sourcegraph\/sourcegraph/, /bucket/],
+            repoMatches: [/sourcegraph\/sourcegraph/, /bucket/],
             fileMatches: [/(web|shared|src)\/.*\.tsx?/, /\/.*\\.ts?/],
             lineMatches: [
                 /throw new Error+\(['"]([^'"]+)['"]\)/,
@@ -69,7 +69,7 @@ export let projects: SentryProject[] = [
         name: 'Dev env errors',
         projectId: '213332',
         patternProperties: {
-            repoMatch: [/dev-repo/],
+            repoMatches: [/dev-repo/],
             fileMatches: [/(dev)\/.*\\.go?/],
             lineMatches: [/log\.(Printf|Print|Println)\(['"]([^'"]+)['"]\)/],
         },


### PR DESCRIPTION
"(Show/Hide) log links" action in command palette and a Sentry icon action item on the editor/title, update README and enable for GitLab.